### PR TITLE
用PBKDF2替代bcrypt，以及Windows相容性修正

### DIFF
--- a/libs/pbkdf2.js
+++ b/libs/pbkdf2.js
@@ -1,0 +1,42 @@
+/*jslint node: true, regexp: true, nomen: true, indent: 2, vars: true */
+
+'use strict';
+
+var crypto = require('crypto');
+// Bcrypt Adoptions:
+// bcrypt.genSalt(rounds, seed_length, callback(err, salt))
+// bcrypt.hash(data, salt, callback(err, encrypted))
+// bcrypt.compare(data, encrypted, function(err, same))
+
+module.exports = {
+  keylen: 256,
+  iterations: 4096,
+  genSalt: function (size, callback) {
+    crypto.randomBytes(size, function (err, buf) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, buf.toString('base64'));
+    });
+  },
+  hash: function (data, salt, callback) {
+    // For iteration count settings, see:
+    // http://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256
+    crypto.pbkdf2(data, salt, this.iterations, this.keylen, function (err, derivedKey) {
+      if (err) {
+        return callback(err);
+      }
+      // derivedKey is string, but stores binary data
+      var buffer = new Buffer(derivedKey);
+      return callback(null, buffer.toString('hex'), salt);
+    });
+  },
+  compare: function (data, encrypted, salt, callback) {
+    this.hash(data, salt, function (err, hash) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, (encrypted === hash));
+    });
+  }
+};

--- a/models/user.js
+++ b/models/user.js
@@ -10,6 +10,7 @@ var UserSchema = new Schema({
   name: { type: String, index: true },
   loginname: { type: String, unique: true },
   pass: { type: String },
+  salt: { type: String },
   email: { type: String, unique: true },
   url: { type: String },
   profile_image_url: {type: String},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "2.5.1",
     "ejs": ">=0.8.0",
     "eventproxy": ">=0.1.0",
-    "mongoose": "2.4.1",
+    "mongoose": "2.9.7",
     "node-markdown": "0.1.0",
     "validator": "0.3.7",
     "ndir": ">=0.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "nodemailer": "0.3.5",
     "data2xml": "0.4.0",
     "xss": ">=0.0.2",
-    "bcrypt ": "*",
     "facebook-group-sync": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
拿掉bcrypt並且使用[crypto.pbkdf2](http://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_callback)的原因是去除node-gyp的相依性，減輕設定開發環境的困難，並維持高安全性的加密。

舉例而言，以下環境無法安裝需要compile的npm package：
- 沒有裝gcc的Linux
- 沒有裝Xcode command line tools的OS X
- 沒有裝Visual Studio的Windows

**此修改不相容現有的user model(bcrypt hash)，並且會在User新增salt欄位**

Windows相容性的修改則是更新了mongoose版本，測了一下沒發現什麼問題
